### PR TITLE
Make unique filenames for payloads that contain duplicate filenames

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -95,6 +95,37 @@ var fixtures = map[string]string{
 		]
 	}
 	`,
+	"archive-duplicate": `
+	{
+		"filename": "",
+		"payloads": [
+			{
+				"url": "http://picocandy.com/images/unknown.png",
+				"filename": "picocandy.png",
+				"content_type": "image/png",
+				"content_length": 3909
+			},
+			{
+				"url": "http://picocandy.com/images/unknown1.png",
+				"filename": "picocandy.png",
+				"content_type": "image/png",
+				"content_length": 3922
+			},
+			{
+				"url": "http://www.gorillatoolkit.org/static/images/gorilla-icon-64.gif",
+				"filename": "picocandy.gif",
+				"content_type": "image/gif",
+				"content_length": 6709
+			},
+			{
+				"url": "http://www.gorillatoolkit.org/static/images/gorilla-icon-64.png",
+				"filename": "Picocandy.png",
+				"content_type": "image/png",
+				"content_length": 6722
+			}
+		]
+	}
+	`,
 	"payload": `
 	{
 		"url": "http://picocandy.com/images/logo.png",

--- a/api/archive.go
+++ b/api/archive.go
@@ -5,10 +5,12 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"github.com/ncw/swift"
 	"io"
 	"io/ioutil"
 	"os"
+	"strings"
 )
 
 type Archive struct {
@@ -140,4 +142,21 @@ func (a *Archive) DownloadURL(cf swift.Connection) (string, error) {
 	}
 
 	return GenerateTempURL(cf, a)
+}
+
+func (a *Archive) RenameDuplicatePayloads() {
+	filenames := make(map[string]int)
+
+	for _, p := range a.Payloads {
+		key := strings.ToLower(p.Filename)
+
+		_, present := filenames[key]
+		if present {
+			filenames[key]++
+			file, ext := SplitFilename(p.Filename)
+			p.Filename = fmt.Sprintf("%s-%d%s", file, filenames[key], ext)
+		} else {
+			filenames[key] = 0
+		}
+	}
 }

--- a/api/archive_test.go
+++ b/api/archive_test.go
@@ -108,3 +108,17 @@ func (s *ArchiveSuite) TestArchive_RemoveTemp(c *check.C) {
 	c.Assert(err, check.NotNil)
 	c.Assert(os.IsNotExist(err), check.Equals, true)
 }
+
+func (s *ArchiveSuite) TestArchive_RenameDuplicatePayloads(c *check.C) {
+	a := &Archive{}
+
+	err := json.Unmarshal([]byte(fixtures["archive-duplicate"]), a)
+	c.Assert(err, check.IsNil)
+
+	a.RenameDuplicatePayloads()
+
+	c.Assert(a.Payloads[0].Filename, check.Equals, "picocandy.png")
+	c.Assert(a.Payloads[1].Filename, check.Equals, "picocandy-1.png")
+	c.Assert(a.Payloads[2].Filename, check.Equals, "picocandy.gif")
+	c.Assert(a.Payloads[3].Filename, check.Equals, "Picocandy-2.png")
+}

--- a/api/http_zip.go
+++ b/api/http_zip.go
@@ -23,6 +23,8 @@ func ZipHandler(w http.ResponseWriter, r *http.Request, cf swift.Connection) {
 		return
 	}
 
+	a.RenameDuplicatePayloads()
+
 	err = cf.Authenticate()
 	if err != nil {
 		internalError(w, "Unable to authenticate to Rackspace Cloud Files")

--- a/api/util.go
+++ b/api/util.go
@@ -80,3 +80,19 @@ func JSON(w http.ResponseWriter, v interface{}, code int) {
 
 	w.Write(s)
 }
+
+func SplitFilename(s string) (string, string) {
+	file := s
+	ext := ""
+
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == '.' {
+			file = s[:i]
+			ext = s[i:]
+
+			break
+		}
+	}
+
+	return file, ext
+}

--- a/api/util_test.go
+++ b/api/util_test.go
@@ -83,3 +83,15 @@ func (s *UtilSuite) TestJSON(c *check.C) {
 		c.Assert(w.Body.String(), check.Equals, e[k])
 	}
 }
+
+func (s *UtilSuite) TestSplitFilename_withExtension(c *check.C) {
+	file, ext := SplitFilename("picocandy.png")
+	c.Assert(file, check.Equals, "picocandy")
+	c.Assert(ext, check.Equals, ".png")
+}
+
+func (s *UtilSuite) TestSplitFilename_withoutExtension(c *check.C) {
+	file, ext := SplitFilename("picocandy")
+	c.Assert(file, check.Equals, "picocandy")
+	c.Assert(ext, check.Equals, "")
+}


### PR DESCRIPTION
Automatically add a numeric suffix to the filenames if multiple files in the payloads have the same filename.

First file will be picocandy.png, second - picocandy-1.png, and subsequently picocandy-(n-1).png.

Original case of the renamed filenames is retained but checking for duplicates is case-insensitive.
